### PR TITLE
fix: don't crash or lose the term when converting a keyword list

### DIFF
--- a/lib/splode.ex
+++ b/lib/splode.ex
@@ -26,6 +26,12 @@ defmodule Splode do
   - `:unknown_error` - The module to use when an error cannot be converted to a known type.
     This is required.
 
+    Splode populates the `:error` and `:vars` fields on this module, so it should declare at
+    least `fields: [:error]`. It may also declare a `:value` field, which receives the whole
+    list when an error is built from a keyword list; if the field is not declared, that option
+    is not passed. See `c:Splode.Error.keyword_list_options?/0` for control over when a keyword
+    list is treated as options at all.
+
   - `:merge_with` - A list of other Splode modules whose errors should be recognized and
     flattened when combined. Optional.
 
@@ -204,6 +210,20 @@ defmodule Splode do
       matcher when is_atom(matcher) -> mod == matcher
       prefix when is_binary(prefix) -> String.starts_with?(inspect(mod), prefix)
     end)
+  end
+
+  @doc false
+  def keyword_options?(unknown_error, term) do
+    Keyword.keyword?(term) and unknown_error.keyword_list_options?()
+  end
+
+  @doc false
+  def put_new_value(opts, unknown_error, value) do
+    if Map.has_key?(unknown_error.__struct__(), :value) do
+      Keyword.put_new(opts, :value, value)
+    else
+      opts
+    end
   end
 
   defmacro __using__(opts) do
@@ -389,7 +409,7 @@ defmodule Splode do
 
       def to_class(values, opts) when is_list(values) do
         errors =
-          if Keyword.keyword?(values) && values != [] do
+          if Splode.keyword_options?(@unknown_error, values) && values != [] do
             [to_error(values, Keyword.delete(opts, :bread_crumbs))]
           else
             values
@@ -465,11 +485,13 @@ defmodule Splode do
       def to_error(value, opts \\ [])
 
       def to_error(list, opts) when is_list(list) do
-        if Keyword.keyword?(list) do
+        if Splode.keyword_options?(@unknown_error, list) do
           list
           |> Keyword.take([:error, :vars])
-          |> Keyword.put_new(:error, list[:message])
-          |> Keyword.put_new(:value, list)
+          |> Keyword.put_new_lazy(:error, fn ->
+            list[:message] || "unknown error: #{inspect(list)}"
+          end)
+          |> Splode.put_new_value(@unknown_error, list)
           |> Keyword.put(:splode, __MODULE__)
           |> @unknown_error.exception()
           |> add_stacktrace(opts[:stacktrace])
@@ -533,12 +555,12 @@ defmodule Splode do
       end
 
       defp flatten_preserving_keywords(list) do
-        if Keyword.keyword?(list) do
+        if Splode.keyword_options?(@unknown_error, list) do
           [list]
         else
           Enum.flat_map(list, fn item ->
             cond do
-              Keyword.keyword?(item) ->
+              Splode.keyword_options?(@unknown_error, item) ->
                 [item]
 
               is_list(item) ->

--- a/lib/splode/error.ex
+++ b/lib/splode/error.ex
@@ -21,6 +21,38 @@ defmodule Splode.Error do
   @callback splode_error?() :: boolean()
   @callback from_json(map) :: struct()
   @callback error_class?() :: boolean()
+
+  @doc """
+  Whether a keyword list should be treated as options for building this error.
+
+  Only consulted for the module configured as a Splode's `:unknown_error`. When it returns
+  `true` — the default — a list that satisfies `Keyword.keyword?/1` is destructured into
+  `:error`, `:vars` and (if declared) `:value`, rather than being converted like any other
+  term.
+
+  That is surprising for terms that happen to parse as keyword lists, such as OTP exit
+  reasons:
+
+  ```elixir
+  Keyword.keyword?([{:noproc, {GenServer, :call, [:some_name, :ping, 5000]}}])
+  #=> true
+  ```
+
+  Returning `false` opts out: keyword lists are then converted like any other list, so
+  `to_error(message: "it broke")` produces two errors rather than one, and `to_error([])`
+  produces an empty error class rather than an unknown error. The default will change to
+  `false` in the next major version.
+
+  ```elixir
+  defmodule MyApp.Errors.Unknown do
+    use Splode.Error, fields: [:error], class: :unknown
+
+    def keyword_list_options?, do: false
+  end
+  ```
+  """
+  @callback keyword_list_options?() :: boolean()
+
   @type t :: Exception.t()
 
   @doc false
@@ -76,6 +108,9 @@ defmodule Splode.Error do
       @impl Splode.Error
       def error_class?, do: @error_class
 
+      @impl Splode.Error
+      def keyword_list_options?, do: true
+
       field_names =
         Enum.map(List.wrap(opts[:fields]), fn
           {k, _v} ->
@@ -121,7 +156,7 @@ defmodule Splode.Error do
         exception(keyword)
       end
 
-      defoverridable exception: 1, from_json: 1
+      defoverridable exception: 1, from_json: 1, keyword_list_options?: 0
     end
   end
 

--- a/test/splode_test.exs
+++ b/test/splode_test.exs
@@ -54,6 +54,19 @@ defmodule SplodeTest do
     def message(err), do: err |> inspect()
   end
 
+  defmodule UnknownErrorWithValue do
+    @moduledoc false
+    use Splode.Error, fields: [:error, :value], class: :unknown
+    def message(err), do: err |> inspect()
+  end
+
+  defmodule OptOutUnknownError do
+    @moduledoc false
+    use Splode.Error, fields: [:error], class: :unknown
+    def keyword_list_options?, do: false
+    def message(err), do: err |> inspect()
+  end
+
   defmodule ExampleContainerError do
     @moduledoc false
     use Splode.Error, fields: [:description], class: :ui
@@ -225,6 +238,65 @@ defmodule SplodeTest do
 
     div_by_zero = DivByZeroException.exception()
     assert %DivByZeroException{} = SystemError.to_error(div_by_zero)
+  end
+
+  describe "to_error/to_class with keyword lists" do
+    defmodule ValueErrors do
+      @moduledoc false
+      use Splode, error_classes: [sw: SwError], unknown_error: UnknownErrorWithValue
+    end
+
+    defmodule OptOutErrors do
+      @moduledoc false
+      use Splode, error_classes: [sw: SwError], unknown_error: OptOutUnknownError
+    end
+
+    @exit_reason {:noproc, {GenServer, :call, [:some_name, :ping, 5000]}}
+
+    test "option lists are built into the unknown error" do
+      assert %UnknownError{error: "it broke"} = SystemError.to_error(message: "it broke")
+      assert %UnknownError{error: "it broke"} = SystemError.to_error(error: "it broke")
+
+      assert %UnknownError{vars: [thing: 1]} =
+               SystemError.to_error(message: "x", vars: [thing: 1])
+    end
+
+    test "an unknown error declaring :value receives the whole list" do
+      assert %UnknownErrorWithValue{error: "it broke", value: [message: "it broke"]} =
+               ValueErrors.to_error(message: "it broke")
+    end
+
+    test "an unknown error without a :value field does not crash" do
+      assert %UnknownError{} = SystemError.to_error([@exit_reason])
+    end
+
+    test "a list carrying no message is described rather than left nil" do
+      assert %UnknownError{error: "unknown error: " <> _} = SystemError.to_error([@exit_reason])
+
+      assert %UnknownErrorWithValue{error: description, value: [@exit_reason]} =
+               ValueErrors.to_error([@exit_reason])
+
+      assert description =~ "noproc"
+      assert description =~ "GenServer"
+    end
+
+    test "an empty list still produces an unknown error" do
+      assert %UnknownError{} = SystemError.to_error([])
+    end
+
+    test "opting out converts a keyword list like any other term" do
+      assert %OptOutUnknownError{error: "unknown error: " <> described} =
+               OptOutErrors.to_error([@exit_reason])
+
+      assert described == inspect(@exit_reason)
+    end
+
+    test "opting out produces one error per term rather than recursing" do
+      class = OptOutErrors.to_class([@exit_reason, {:shutdown, :closed}])
+
+      assert %Splode.Error.Unknown{} = class
+      assert [%OptOutUnknownError{}, %OptOutUnknownError{}] = class.errors
+    end
   end
 
   describe "traverse_errors" do


### PR DESCRIPTION
Fixes #126.

Two separate faults in `to_error/2`'s keyword-list branch. Only one of them is about routing, and it turns out not to need a routing change.

## The crash

`Keyword.put_new(:value, list)` passed `:value` to the configured `unknown_error` unconditionally. Only `Ash.Error.Unknown.UnknownError` declares that field, so for every other unknown error `struct!/2` raised `KeyError: key :value not found` — including the `fields: [:error]` shape used throughout splode's own documentation and tests, and `Reactor.Error.Unknown.UnknownError` verbatim. Every keyword list crashed, the documented `[message: "..."]` case included.

`:value` is now only passed when the unknown error declares the field.

## The lost term

`Keyword.put_new(:error, list[:message])` leaves `error: nil` for a list that carries no `:message` — which is every term that only incidentally parses as a keyword list, OTP exit reasons among them:

```elixir
Keyword.keyword?([{:noproc, {GenServer, :call, [:some_name, :ping, 5000]}}])
#=> true
```

The reason survived only in `:value`, and both Ash's and reactor's `message/1` render just `:error`, so it rendered as `nil`. A list carrying neither `:message` nor `:error` is now described the way the catch-all describes any other term:

```
## `error`:

unknown error: [noproc: {GenServer, :call, [:some_name, :ping, 5000]}]
```

No content inspection is involved: routing still uses plain `Keyword.keyword?/1`, so a term is faithfully described whether or not it parses as a keyword list, and there is no behaviour change for real option lists.

## The flip

Whether keyword lists are treated as options at all is now `c:Splode.Error.keyword_list_options?/0` on the unknown error, defaulting to `true` — today's behaviour. Returning `false` sends keyword lists down the generic path, and it is documented as becoming the default in the next major version.

The callback is consulted at all three sites that decide this — `to_error/2`, `to_class/2` and `flatten_preserving_keywords/1`. They have to agree: gating only `to_error/2` leaves `flatten_preserving_keywords/1` handing a multi-element keyword list straight back, which ping-pongs between it and `to_class/2` forever.

## Compatibility

No behaviour change under the default. `to_error(foo: 1, bar: 2)` is still one unknown error; option lists still populate `:error`, `:vars` and `:value`. The only difference is that a list which previously produced `error: nil` now produces a description of itself.

Verified against `mix check --no-retry`, ash's suite (3776 tests) and reactor's suite (358 tests) with `{:splode, path: "../splode", override: true}`, plus the exit reason from the original report rendering rather than raising.
